### PR TITLE
LED Framerate limiting, and Flywheel tuning

### DIFF
--- a/src/main/java/com/team1806/frc2020/Constants.java
+++ b/src/main/java/com/team1806/frc2020/Constants.java
@@ -189,10 +189,10 @@ public class Constants {
     // flywheel
     public static final int kFlywheelSparkMaxLeader = 30;
     public static final int kFlywheelSparkMaxFollower = 31;
-    public static final double kFlywheelSpeedControlkp = .01;
+    public static final double kFlywheelSpeedControlkp = 0.001;//.0085;
     public static final double kFlywheelSpeedControlki = 0;
-    public static final double kFlywheelSpeedControlkd = 0.001;
-    public static final double kFlywheelSpeedControlkf = 0.012;
+    public static final double kFlywheelSpeedControlkd = 0.000;
+    public static final double kFlywheelSpeedControlkf = 0.0002001;
     public static final double kFlywheelAcceptableSpeedRange = 100;
     public static final double kFlywheelAcceptableAccleration = 100;
     public static final double kFlywheelGearScalingFactor = 35.0 / 18.0;

--- a/src/main/java/com/team1806/frc2020/subsystems/Flywheel.java
+++ b/src/main/java/com/team1806/frc2020/subsystems/Flywheel.java
@@ -1,6 +1,7 @@
 package com.team1806.frc2020.subsystems;
 
 
+import com.revrobotics.CANError;
 import com.revrobotics.CANSparkMax;
 import com.revrobotics.ControlType;
 import com.team1806.frc2020.Constants;
@@ -8,6 +9,8 @@ import com.team1806.lib.drivers.LazySparkMax;
 import com.team1806.lib.util.ReflectingCSVWriter;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+
+import java.util.ArrayList;
 
 public class Flywheel extends Subsystem {
 
@@ -84,11 +87,13 @@ public class Flywheel extends Subsystem {
 
     private void reloadGains() {
         if (mSparkMaxLeader != null && mSparkMaxLeader.getPIDController() != null) {
-            mSparkMaxLeader.getPIDController().setP(Constants.kFlywheelSpeedControlkp);
-            mSparkMaxLeader.getPIDController().setI(Constants.kFlywheelSpeedControlki);
-            mSparkMaxLeader.getPIDController().setD(Constants.kFlywheelSpeedControlkd);
-            mSparkMaxLeader.getPIDController().setFF(Constants.kFlywheelSpeedControlkf);
-            mSparkMaxLeader.getPIDController().setOutputRange(0, 1);
+            ArrayList<CANError> errors = new ArrayList<>();
+            errors.add(mSparkMaxLeader.getPIDController().setP(Constants.kFlywheelSpeedControlkp));
+            errors.add(mSparkMaxLeader.getPIDController().setI(Constants.kFlywheelSpeedControlki));
+            errors.add(mSparkMaxLeader.getPIDController().setD(Constants.kFlywheelSpeedControlkd));
+            errors.add(mSparkMaxLeader.getPIDController().setFF(Constants.kFlywheelSpeedControlkf, 0));
+            errors.add(mSparkMaxLeader.getPIDController().setOutputRange(0, 1));
+            System.out.println(errors);
         }
     }
 

--- a/src/main/java/com/team1806/frc2020/subsystems/LEDStringSubsystem.java
+++ b/src/main/java/com/team1806/frc2020/subsystems/LEDStringSubsystem.java
@@ -17,11 +17,13 @@ public class LEDStringSubsystem extends Subsystem {
     private AddressableLEDBuffer mLEDBuffer;
     private int mNumOfLEDs;
     private boolean stopOnDisable;
+    private double lastUpdateTime;
 
     private LEDPattern currentPattern;
 
 
     public LEDStringSubsystem(int port, int mNumOfLEDs, boolean stopOnDisable) {
+        lastUpdateTime = 0;
         this.mLED = new AddressableLED(port);
         this.mNumOfLEDs = mNumOfLEDs;
         this.mLEDBuffer = new AddressableLEDBuffer(mNumOfLEDs);
@@ -42,13 +44,16 @@ public class LEDStringSubsystem extends Subsystem {
 
             @Override
             public void onLoop(double timestamp) {
-                //System.out.println("Running LED onLoop()");
+                if(currentPattern.getFPS() == 0)
+                {
+                    return;
+                }
+                if(timestamp - lastUpdateTime > 1.0 / currentPattern.getFPS()) {
                     currentPattern.updateAnimation();
-                   // System.out.println("Animation Updated");
                     IntStream.range(0, mLEDBuffer.getLength()).forEach(i -> mLEDBuffer.setLED(i, currentPattern.getColorForPositionInString(i)));
-                    //System.out.println("LED buffer values updated");
                     mLED.setData(mLEDBuffer);
-                    //System.out.println("Finished LED onLoop()");
+                    lastUpdateTime = timestamp;
+                }
             }
 
             @Override

--- a/src/main/java/com/team1806/lib/util/LED/GlitchyLEDPattern.java
+++ b/src/main/java/com/team1806/lib/util/LED/GlitchyLEDPattern.java
@@ -32,6 +32,9 @@ public class GlitchyLEDPattern implements LEDPattern {
     }
 
 
+    /**
+     *{@inheritDoc}
+     */
     @Override
     public Color getColorForPositionInString(int position) {
         if(mIntsForFun.noneMatch(new IntPredicate() {
@@ -48,6 +51,9 @@ public class GlitchyLEDPattern implements LEDPattern {
 
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void updateAnimation() {
         //choose your corruption
@@ -157,6 +163,14 @@ public class GlitchyLEDPattern implements LEDPattern {
                 return mLEDBuffer.getLED((position + mIntsForFun.toArray()[2]) % mLEDBuffer.getLength());
             case 13:
                 return Color.kDarkGray;
+
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int getFPS(){
+        return 60;
     }
 }

--- a/src/main/java/com/team1806/lib/util/LED/LEDPattern.java
+++ b/src/main/java/com/team1806/lib/util/LED/LEDPattern.java
@@ -7,7 +7,22 @@ import java.util.List;
 
 public interface LEDPattern {
 
+    /**
+     * Get the desired color for a given position in an LED String
+     * @param position the desired position in the LED string, 0-indexed
+     * @return the color the pattern needs in that position.
+     */
     public Color getColorForPositionInString(int position);
 
+    /**
+     * Advances the animation one frame
+     */
     public void updateAnimation();
+
+    /**
+     * Get the frame rate the animation is designed to be animated at.
+     * @return the frame rate for the animation
+     */
+    public int getFPS();
+
 }

--- a/src/main/java/com/team1806/lib/util/LED/ScrollingLEDPattern.java
+++ b/src/main/java/com/team1806/lib/util/LED/ScrollingLEDPattern.java
@@ -6,24 +6,39 @@ import java.util.Arrays;
 import java.util.List;
 
 public class ScrollingLEDPattern implements LEDPattern {
-    public static final ScrollingLEDPattern VISION_GREEN = new ScrollingLEDPattern(Arrays.asList(Color.kGreen), 0);
-    public static final ScrollingLEDPattern BLACK_AND_WHITE = new ScrollingLEDPattern(Arrays.asList(Color.kBlack, Color.kBlack, Color.kBlack, Color.kWhite, Color.kWhite, Color.kWhite), 1);
-    public static final ScrollingLEDPattern ECTOPLASM = new ScrollingLEDPattern(Arrays.asList(Color.kDarkGreen, Color.kLimeGreen, Color.kLimeGreen, Color.kDarkGreen, Color.kBlack, Color.kBlack, Color.kBlack, Color.kBlack), 2);
+    public static final ScrollingLEDPattern VISION_GREEN = new ScrollingLEDPattern(Arrays.asList(Color.kGreen), 0, 0);
+    public static final ScrollingLEDPattern BLACK_AND_WHITE = new ScrollingLEDPattern(Arrays.asList(Color.kBlack, Color.kBlack, Color.kBlack, Color.kWhite, Color.kWhite, Color.kWhite), 1, 60);
+    public static final ScrollingLEDPattern ECTOPLASM = new ScrollingLEDPattern(Arrays.asList(Color.kDarkGreen, Color.kLimeGreen, Color.kLimeGreen, Color.kDarkGreen, Color.kBlack, Color.kBlack, Color.kBlack, Color.kBlack), 2, 60);
 
     private List<Color> pattern;
     private int animationStepAmount;
     private int currentAnimationStep;
+    private int FPS;
 
-    public ScrollingLEDPattern(List<Color> pattern, int animationStepAmount) {
+    public ScrollingLEDPattern(List<Color> pattern, int animationStepAmount, int FPS) {
         this.pattern = pattern;
         this.animationStepAmount = animationStepAmount;
+        this.FPS = FPS;
     }
 
+    /**
+     *{@inheritDoc}
+     */
     public Color getColorForPositionInString(int position){
         return pattern.get(Math.abs(position-currentAnimationStep) % pattern.size());
     }
 
+    /**
+     *{@inheritDoc}
+     */
     public void updateAnimation(){
         currentAnimationStep += animationStepAmount;
+    }
+
+    /**
+     *{@inheritDoc}
+     */
+    public int getFPS(){
+        return FPS;
     }
 }


### PR DESCRIPTION
limited LEDs and tuned Flywheel a bit, noticed calls to setFF on the SparkMax's PID controller isn't working.

``` [CAN SPARK MAX] WPILib or External HAL Error: CAN: Message not found ```
This message is getting printed from the Flywheel subsystem's reload gains function, and the kF for slot 0 on the controller stays 0 regardless of what value we send it. Can be worked around for now by using the REV Hardware client and manually setting the value there, but it would be nice to have this fixed by the next in person competition.
